### PR TITLE
Minor env-related fixes

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,18 +23,17 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-        env:
-          CI: true
-          CC_SECRET: ${{ secrets.CC_SECRET }}
-          GG_SECRET: ${{ secrets.GG_SECRET }}
-          GH_SECRET: ${{ secrets.GH_SECRET }}
-          LOCAL_MONGODB: ${{ secrets.LOCAL_MONGODB }}
-          REMOTE_MONGODB: ${{ secrets.REMOTE_MONGODB }}
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0
       - run: cd backend && yarn install
       - run: cd backend && yarn build
       - run: cd backend && yarn test:cov
+        env:
+          CC_SECRET: ${{ secrets.CC_SECRET }}
+          GG_SECRET: ${{ secrets.GG_SECRET }}
+          GH_SECRET: ${{ secrets.GH_SECRET }}
+          LOCAL_MONGODB: ${{ secrets.LOCAL_MONGODB }}
+          REMOTE_MONGODB: ${{ secrets.REMOTE_MONGODB }}
 
   frontend:
     name: front end

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,6 +23,13 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+        env:
+          CI: true
+          CC_SECRET: ${{ secrets.CC_SECRET }}
+          GG_SECRET: ${{ secrets.GG_SECRET }}
+          GH_SECRET: ${{ secrets.GH_SECRET }}
+          LOCAL_MONGODB: ${{ secrets.LOCAL_MONGODB }}
+          REMOTE_MONGODB: ${{ secrets.REMOTE_MONGODB }}
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0
       - run: cd backend && yarn install

--- a/backend/src/secrets.ts
+++ b/backend/src/secrets.ts
@@ -2,5 +2,7 @@ export const Secrets = {
   CoderCommunityJwtSecret: process.env.CC_SECRET,
   GitHubOAuthClientSecret: process.env.GH_SECRET,
   GoogleOAuthClientSecret: process.env.GG_SECRET,
-  MongoConnectionString: (process.env.CI || process.env.USE_LOCAL_MONGODB) ? process.env.LOCAL_MONGODB : process.env.REMOTE_MONGODB
+  MongoConnectionString: (process.env.CI || (process.env.USE_LOCAL_MONGODB && process.env.USE_LOCAL_MONGODB !== "false")) ? process.env.LOCAL_MONGODB : process.env.REMOTE_MONGODB
 };
+
+console.log(process.env);


### PR DESCRIPTION
- `.env`'s `USE_LOCAL_MONGODB=false` will be treated as false. Previously, `"false"` string was truthy.
- GitHub actions now use the GitHub secrets as environment variables